### PR TITLE
Load bootstrap resources over https to avoid mixed-content warnings.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,12 +7,12 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="">
         <meta name="author" content="">
-        <link rel="icon" href="http://getbootstrap.com/favicon.ico">
+        <link rel="icon" href="https://getbootstrap.com/favicon.ico">
 
         <title>{% load i18n %}{% trans "Bikes without Borders" %}</title>
 
-        <link href="http://getbootstrap.com/dist/css/bootstrap.min.css" rel="stylesheet">
-        <link href="http://getbootstrap.com/examples/dashboard/dashboard.css" rel="stylesheet">
+        <link href="https://getbootstrap.com/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link href="https://getbootstrap.com/examples/dashboard/dashboard.css" rel="stylesheet">
 
         <!--[if lt IE 9]>
           <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
@@ -72,9 +72,9 @@
         ================================================== -->
         <!-- Placed at the end of the document so the pages load faster -->
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-        <script src="http://getbootstrap.com/dist/js/bootstrap.min.js"></script>
+        <script src="https://getbootstrap.com/dist/js/bootstrap.min.js"></script>
         <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-        <script src="http://getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
+        <script src="https://getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.15.0/jquery.validate.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.15.0/additional-methods.min.js"></script>

--- a/templates/staff/base_staff.html
+++ b/templates/staff/base_staff.html
@@ -9,13 +9,13 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="">
         <meta name="author" content="">
-        <link rel="icon" href="http://getbootstrap.com/favicon.ico">
+        <link rel="icon" href="https://getbootstrap.com/favicon.ico">
 
         <title>{% load i18n %}{% trans "Bikes without Borders" %}</title>
 
-        <link href="http://getbootstrap.com/dist/css/bootstrap.min.css"
+        <link href="https://getbootstrap.com/dist/css/bootstrap.min.css"
         rel="stylesheet">
-        <link href="http://getbootstrap.com/examples/dashboard/dashboard.css"
+        <link href="https://getbootstrap.com/examples/dashboard/dashboard.css"
         rel="stylesheet">
     </head>
 
@@ -72,7 +72,7 @@
             </div>
         </div>
 
-        <div class="container-fluid">        
+        <div class="container-fluid">
             <div class="col-sm-3 col-md-2 sidebar">
                 {% block side_block %}
                 {% get_event_list event.id %}
@@ -89,9 +89,9 @@
         ================================================== -->
         <!-- Placed at the end of the document so the pages load faster -->
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-        <script src="http://getbootstrap.com/dist/js/bootstrap.min.js"></script>
+        <script src="https://getbootstrap.com/dist/js/bootstrap.min.js"></script>
         <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-        <script src="http://getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
+        <script src="https://getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.15.0/jquery.validate.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.15.0/additional-methods.min.js"></script>


### PR DESCRIPTION
https://support.mozilla.org/en-US/kb/mixed-content-blocking-firefox
